### PR TITLE
Fix null data in transfer query output

### DIFF
--- a/prisma/base/transaction.prisma
+++ b/prisma/base/transaction.prisma
@@ -16,7 +16,7 @@ model Transaction {
   targetAmount             Float
   targetCurrency           String
   transferState            String
-  transferStateChanges     TransferStateChange[]
+  transferStateChanges     Json
   transactionType          String
   errorCode                Int?
   transferSettlementWindowId Int
@@ -38,15 +38,4 @@ model Transaction {
   @@index([transactionType])
 
   @@map("transfer")
-}
-
-model TransferStateChange {
-  id                        String   @id @default(auto()) @map("_id") @db.ObjectId
-  transferState             String
-  dateTime                  DateTime
-  reason                    String?
-  transactionId             String   @db.ObjectId
-  transaction               Transaction @relation(fields: [transactionId], references: [id])
-  createdAt                 DateTime @default(now())
-  @@index([transferState])
 }

--- a/prisma/base/transaction.prisma
+++ b/prisma/base/transaction.prisma
@@ -16,7 +16,7 @@ model Transaction {
   targetAmount             Float
   targetCurrency           String
   transferState            String
-  transferStateChanges     Json
+  transferStateChanges     TransferStateChange[]
   transactionType          String
   errorCode                Int?
   transferSettlementWindowId Int
@@ -24,12 +24,12 @@ model Transaction {
   payerDFSPProxy          String?
   payeeDFSP               String?
   payeeDFSPProxy          String?
-  positionChanges         Json
-  payerParty              Json
-  payeeParty              Json
-  quoteRequest            Json
-  transferTerms           Json
-  conversions             Json
+  positionChanges         PositionChange[]
+  payerParty              Party
+  payeeParty              Party
+  quoteRequest            QuoteRequest
+  transferTerms           TransferTerms
+  conversions             Conversions[]
   createdAt               DateTime @default(now())
   lastUpdated               DateTime? @updatedAt
   @@unique([transferId])
@@ -38,4 +38,87 @@ model Transaction {
   @@index([transactionType])
 
   @@map("transfer")
+}
+type TransferStateChange {
+  transferState  String
+  dateTime       DateTime @db.Date
+  reason         String?
+}
+
+type PositionChange {
+  change          Float
+  currency        String
+  dateTime        DateTime @db.Date
+  ledgerType      String
+  participantName String
+  updatedPosition Float
+}
+
+type TransferTerms {
+  expiration         DateTime @db.Date
+  geoCode            GeoCode
+  ilpPacket          String
+  payeeFspCommission Amount
+  payeeFspFee        Amount
+  payeeReceiveAmount Amount
+  transferAmount     Amount
+}
+type GeoCode {
+  latitude  String
+  longitude String
+}
+type Amount {
+  amount  Float
+  currency String
+}
+
+type Conversions {
+  conversionCommitRequestId    String
+  conversionId                 String
+  conversionRequestId          String
+  conversionSettlementWindowId BigInt
+  conversionState              String
+  conversionStateChanges       ConversionStateChanges[]
+  conversionTerms              ConversionTerms
+  conversionType               String
+  counterPartyFSP              String
+}
+
+type ConversionStateChanges {
+  conversionState String
+  dateTime        DateTime @db.Date
+  reason          String
+}
+
+type ConversionTerms {
+  amountType            String
+  charges               ConversionTermsCharges[]
+  conversionId          String
+  counterPartyFsp       String
+  determiningTransferId String
+  expiration            DateTime @db.Date
+  ilpPacket             String
+  initiatingFsp         String
+  sourceAmount          Amount
+  targetAmount          Amount
+}
+
+type ConversionTermsCharges {
+  chargeType   String
+  sourceAmount Amount
+  targetAmount Amount
+}
+
+type QuoteRequest {
+  amount     Amount
+  amountType String
+  fees       Amount
+  quoteId    String
+}
+
+type Party {
+  partyIdType         String
+  partyIdentifier     String
+  partyName           String
+  supportedCurrencies String
 }

--- a/src/schema/Transfer/Query.ts
+++ b/src/schema/Transfer/Query.ts
@@ -1,4 +1,4 @@
-import { arg, extendType, inputObjectType, intArg, nonNull, stringArg } from 'nexus';
+import { arg, extendType, inputObjectType, intArg, nonNull, stringArg, list } from 'nexus';
 
 const Query = extendType({
   type: 'Query',
@@ -9,7 +9,7 @@ const Query = extendType({
         transferId: nonNull(stringArg()),
       },
       resolve: async (parent, args, ctx) => {
-        console.log("Transfer resolver called for transferId", args.transferId);
+        console.log('Transfer resolver called for transferId', args.transferId);
         const transaction = await ctx.transaction.transaction.findUnique({
           where: {
             transferId: args.transferId,
@@ -19,8 +19,29 @@ const Query = extendType({
           console.log('no transaction found ');
           return null;
         }
-        console.log('transaction data:',transaction);
+        console.log('transaction data:', transaction);
         return transaction;
+      },
+    });
+    t.nonNull.list.nonNull.field('getAllTransfers', {
+      type: 'Transfer',
+      args: {
+        limit: intArg(),
+        offset: intArg(),
+      },
+      resolve: async (parent, args, ctx) => {
+        const { limit = 10, offset = 0 } = args;
+        console.log(`Fetching transfers with limit ${limit} and offset ${offset}`);
+        const transfers = await ctx.transaction.transaction.findMany({
+          skip: offset ?? 0,
+          take: limit ?? 5,
+          orderBy: {
+            createdAt: 'desc',
+          },
+        });
+
+        console.log('Transfers fetched with pagination:', transfers);
+        return transfers;
       },
     });
   },

--- a/src/schema/Transfer/Query.ts
+++ b/src/schema/Transfer/Query.ts
@@ -1,5 +1,14 @@
-import { arg, extendType, inputObjectType, intArg, nonNull, stringArg, list } from 'nexus';
+/**************************************************************************
+ *  (C) Copyright Mojaloop Foundation 2020                                *
+ *                                                                        *
+ *  This file is made available under the terms of the license agreement  *
+ *  specified in the corresponding source code repository.                *
+ *                                                                        *
+ *  ORIGINAL AUTHOR:                                                      *
+ *       Yevhen Kyriukha <yevhen.kyriukha@modusbox.com>                   *
+ **************************************************************************/
 
+import { extendType, intArg, nonNull, stringArg } from 'nexus';
 const Query = extendType({
   type: 'Query',
   definition(t) {
@@ -9,20 +18,26 @@ const Query = extendType({
         transferId: nonNull(stringArg()),
       },
       resolve: async (parent, args, ctx) => {
-        console.log('Transfer resolver called for transferId', args.transferId);
-        const transaction = await ctx.transaction.transaction.findUnique({
-          where: {
-            transferId: args.transferId,
-          },
-        });
-        if (!transaction) {
-          console.log('no transaction found ');
-          return null;
+        try {
+          const transaction = await ctx.transaction.transaction.findUnique({
+            where: {
+              transferId: args.transferId,
+            },
+          });
+
+          if (!transaction) {
+            console.log(`No transaction found for transferId: ${args.transferId}`);
+            return null;
+          }
+
+          return transaction;
+        } catch (error) {
+          console.error(`Error fetching transaction with transferId: ${args.transferId}`, error);
+          throw new Error('Error fetching transaction data');
         }
-        console.log('transaction data:', transaction);
-        return transaction;
       },
     });
+
     t.nonNull.list.nonNull.field('getAllTransfers', {
       type: 'Transfer',
       args: {
@@ -30,18 +45,25 @@ const Query = extendType({
         offset: intArg(),
       },
       resolve: async (parent, args, ctx) => {
-        const { limit = 10, offset = 0 } = args;
-        console.log(`Fetching transfers with limit ${limit} and offset ${offset}`);
-        const transfers = await ctx.transaction.transaction.findMany({
-          skip: offset ?? 0,
-          take: limit ?? 5,
-          orderBy: {
-            createdAt: 'desc',
-          },
-        });
+        try {
+          const { limit = 10, offset = 0 } = args;
+          const transfers = await ctx.transaction.transaction.findMany({
+            skip: offset ?? 0,
+            take: limit ?? 5,
+            orderBy: {
+              createdAt: 'desc',
+            },
+          });
 
-        console.log('Transfers fetched with pagination:', transfers);
-        return transfers;
+          if (transfers.length === 0) {
+            console.log(`No transfers found with limit: ${limit} and offset: ${offset}`);
+          }
+
+          return transfers;
+        } catch (error) {
+          console.error('Error fetching transfers', error);
+          throw new Error('Error fetching transfers data');
+        }
       },
     });
   },

--- a/src/schema/Transfer/Transfer.ts
+++ b/src/schema/Transfer/Transfer.ts
@@ -1,18 +1,37 @@
 import { objectType } from 'nexus';
 
+const TransferStateChange = objectType({
+  name: 'TransferStateChange',
+  definition(t) {
+    t.nonNull.string('transferState');
+
+    t.nonNull.dateTime('dateTime', {
+      resolve: (parent) => {
+        const date = parent.dateTime;
+        if (date && typeof date === 'object' && date.$date) {
+          return new Date(date.$date).toISOString();
+        }
+        return date ? new Date(date).toISOString() : null;
+      },
+    });
+
+    t.string('reason');
+  },
+});
+
 const Transfer = objectType({
   name: 'Transfer',
   definition(t) {
+    t.nonNull.string('id');
     t.nonNull.string('transferId');
     t.string('transactionId');
     t.decimal('sourceAmount');
     t.string('sourceCurrency');
     t.decimal('targetAmount');
     t.string('targetCurrency');
-    t.string('createdAt');
-    t.string('lastUpdated');
+    t.dateTime('createdAt'); 
+    t.dateTime('lastUpdated');
     t.string('transferState');
-    t.list.field('transferStateChanges', { type: 'JSONObject' }); 
     t.string('transactionType');
     t.int('errorCode');
     t.string('transferSettlementWindowId');
@@ -20,13 +39,33 @@ const Transfer = objectType({
     t.string('payerDFSPProxy');
     t.string('payeeDFSP');
     t.string('payeeDFSPProxy');
-    t.field('positionChanges', { type: 'JSONObject' });
     t.field('payerParty', { type: 'JSONObject' });
     t.field('payeeParty', { type: 'JSONObject' });
     t.field('quoteRequest', { type: 'JSONObject' });
     t.field('transferTerms', { type: 'JSONObject' });
-    t.field('conversions', { type: 'JSONObject' });
+
+    t.list.field('positionChanges', { type: 'JSONObject' });
+
+    t.list.field('transferStateChanges', {
+      type: 'TransferStateChange',
+      resolve: (parent) => {
+        const transferStateChanges = parent.transferStateChanges;
+
+        if (typeof transferStateChanges === 'string') {
+          try {
+            return JSON.parse(transferStateChanges);
+          } catch (error) {
+            console.error('Error parsing transferStateChanges:', error);
+            return [];
+          }
+        }
+
+        return transferStateChanges || [];
+      },
+    });
+
+    t.list.field('conversions', { type: 'JSONObject' });
   },
 });
 
-export default [Transfer];
+export default [Transfer, TransferStateChange];


### PR DESCRIPTION
- Fixed issue where null data was returned in the GraphQL `transfers` query output.
- Created Prisma schema types for MongoDB embedded document JSON objects to correctly map transaction data.
- Defined `Transaction` object type in the GraphQL schema.
- Added a new `getAllTransfers` query to fetch multiple transfer records with pagination support (limit and offset).